### PR TITLE
Enhance Live Contest Leaderboard with Auth Integration and Display Na…

### DIFF
--- a/docs/weekly-contests/weekly-contests-api-contest-live-leaderboard.md
+++ b/docs/weekly-contests/weekly-contests-api-contest-live-leaderboard.md
@@ -45,7 +45,7 @@ Standings use the same pipeline as E2 scoring: `loadQualifyingSlate` → `tallyS
 | `eventSource` | `string` | Same as `results/final` (e.g. `gameplayEvents_first_n_bio_ball_after_join`). |
 | `entrantsConsidered` | `number` | Entry docs read (≤ 500). |
 | `entrantsCapped` | `boolean` | `true` if `entrantsConsidered` hit the cap. |
-| `standings` | `array` | Same row shape as [weekly-contests-schema-results.md](weekly-contests-schema-results.md#standing-row) (`rank`, `uid`, `wins`, `gamesPlayed`, `losses`, `abandoned`, `displayName`, `tieBreakKey`, `tier`). |
+| `standings` | `array` | Same row shape as [weekly-contests-schema-results.md](weekly-contests-schema-results.md#standing-row) (`rank`, `uid`, `wins`, `gamesPlayed`, `losses`, `abandoned`, `displayName`, `tieBreakKey`, `tier`). **`displayName`:** join snapshot when present; otherwise **Firebase Auth email local part** (never full email); if still absent, clients may show `uid`. |
 | `cache` | `object` | **`{ hit: boolean }`** — `hit: true` when served from TTL cache. |
 
 ## Errors

--- a/docs/weekly-contests/weekly-contests-schema-results.md
+++ b/docs/weekly-contests/weekly-contests-schema-results.md
@@ -40,7 +40,7 @@
 | `gamesPlayed` | `number` | Yes | Games in slate (≤ `leagueGamesN`). |
 | `losses` | `number` | Yes | Losses in slate. |
 | `abandoned` | `number` | Yes | Abandoned games in slate. |
-| `displayName` | `string` \| `null` | No | Optional snapshot for UI. |
+| `displayName` | `string` \| `null` | No | Join-time snapshot when set; otherwise E2 / live API may fill **Auth email local part** (same rule as `resolvedUserDisplayName` in the SPA) so the UI need not fall back to raw `uid`. |
 | `tieBreakKey` | `string` | Yes | Deterministic key for this row (e.g. uid used as final tie-break). |
 | `tier` | `string` | No | **`full`** \| **`partial`** — Tier A vs B per ADR (optional clarity). |
 

--- a/server/contests/contest-live-leaderboard.http.js
+++ b/server/contests/contest-live-leaderboard.http.js
@@ -3,6 +3,8 @@
  * Phase 1 — same computation as E2 (`computeStandingsForEntryDocs`); read-only, no auth required.
  */
 import { z } from 'zod';
+import admin from 'firebase-admin';
+import { getAuth } from 'firebase-admin/auth';
 import { Timestamp } from 'firebase-admin/firestore';
 import { getAdminFirestore } from '../lib/admin-firestore.js';
 import { firestoreTimestampToIso } from '../lib/firestore-timestamp-iso.js';
@@ -250,6 +252,7 @@ export async function getContestLiveLeaderboard(req, res) {
       db,
       { windowStart: ws, windowEnd: we, leagueGamesN },
       entriesSnap.docs,
+      { auth: getAuth(admin.app()) },
     );
 
     const computedAtIso = new Date().toISOString();

--- a/server/contests/contest-scoring-job.js
+++ b/server/contests/contest-scoring-job.js
@@ -2,8 +2,11 @@
  * Contest scoring job — loads entries + gameplay events, writes B3 artifacts, moves scoring→paid.
  * Story E2.
  */
+import admin from 'firebase-admin';
+import { getAuth } from 'firebase-admin/auth';
 import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { randomBytes } from 'node:crypto';
+import { ensureFirebaseAdminInitialized } from '../lib/firebase-admin-init.js';
 import { buildDryRunPayoutLines, EVENT_SOURCE, TIE_BREAK_POLICY } from './contest-scoring-core.js';
 import { computeStandingsForEntryDocs } from './contest-standings-compute.js';
 import { buildTieResolutionAudit } from './contest-scoring-tie-audit.js';
@@ -131,11 +134,13 @@ export async function runContestScoringJob({ db, contestId, scoringJobId, reques
 
   const entriesSnap = await db.collection(`contests/${contestId}/entries`).get();
 
+  ensureFirebaseAdminInitialized();
   const standings = await computeStandingsForEntryDocs(
     db,
     { windowStart: ws, windowEnd: we, leagueGamesN },
     entriesSnap.docs,
     {
+      auth: getAuth(admin.app()),
       onSkipEntry: ({ uid, reason }) => {
         logContestScoringLine({
           requestId,

--- a/server/contests/contest-standings-compute.js
+++ b/server/contests/contest-standings-compute.js
@@ -5,6 +5,10 @@
  */
 
 import { Timestamp } from 'firebase-admin/firestore';
+import {
+  contestStandingDisplayLabel,
+  fetchAuthFieldsForUids,
+} from '../lib/auth-display-names.js';
 import { assignDenseRanks, tallySlate } from './contest-scoring-core.js';
 
 const BIO_BALL = 'bio-ball';
@@ -94,17 +98,20 @@ export async function loadQualifyingSlate(
  *   leagueGamesN: number,
  * }} contestTiming
  * @param {import('firebase-admin/firestore').QueryDocumentSnapshot[]} entryDocs
- * @param {{ onSkipEntry?: (detail: { uid: string, reason: string }) => void }} [hooks]
+ * @param {{
+ *   onSkipEntry?: (detail: { uid: string, reason: string }) => void,
+ *   auth?: import('firebase-admin/auth').Auth,
+ * }} [opts]
  * @returns {Promise<ContestStandingRow[]>}
  */
 export async function computeStandingsForEntryDocs(
   db,
   contestTiming,
   entryDocs,
-  hooks = {},
+  opts = {},
 ) {
   const { windowStart: ws, windowEnd: we, leagueGamesN } = contestTiming;
-  const { onSkipEntry } = hooks;
+  const { onSkipEntry, auth } = opts;
 
   const rows = await Promise.all(
     entryDocs.map(async (entryDoc) => {
@@ -129,7 +136,7 @@ export async function computeStandingsForEntryDocs(
         leagueGamesN,
       );
       const tall = tallySlate(slateEvents, leagueGamesN);
-      const displayName =
+      const displayNameSnapshot =
         ed.displayNameSnapshot === null || typeof ed.displayNameSnapshot === 'string'
           ? ed.displayNameSnapshot
           : null;
@@ -142,7 +149,7 @@ export async function computeStandingsForEntryDocs(
         gamesPlayed: tall.gamesPlayed,
         losses: tall.losses,
         abandoned: tall.abandoned,
-        displayName,
+        displayNameSnapshot,
         tieBreakKey: `uid:${uid}`,
         tier,
       };
@@ -151,6 +158,27 @@ export async function computeStandingsForEntryDocs(
 
   /** @type {object[]} */
   const standingInputs = rows.filter((r) => r != null);
+
+  const needsEmailLabel = standingInputs.filter((r) => {
+    const s = r.displayNameSnapshot;
+    return !(typeof s === 'string' && s.trim());
+  });
+  const uidsForAuth = [...new Set(needsEmailLabel.map((r) => r.uid))];
+  /** @type {Map<string, { email: string | null }>} */
+  let authByUid = new Map();
+  if (auth && uidsForAuth.length > 0) {
+    authByUid = await fetchAuthFieldsForUids(uidsForAuth, auth);
+  }
+
+  for (const row of standingInputs) {
+    const authRow = authByUid.get(row.uid);
+    row.displayName = contestStandingDisplayLabel(
+      row.displayNameSnapshot,
+      authRow?.email,
+    );
+    delete row.displayNameSnapshot;
+  }
+
   assignDenseRanks(standingInputs, leagueGamesN);
 
   return standingInputs.map((row) => ({

--- a/server/contests/contest-standings-compute.test.js
+++ b/server/contests/contest-standings-compute.test.js
@@ -193,6 +193,40 @@ describe('computeStandingsForEntryDocs', () => {
     );
   });
 
+  it('uses Auth email local part when snapshot empty and auth provided', async () => {
+    const ws = ts(0);
+    const we = ts(10_000_000);
+    const leagueGamesN = 2;
+    const db = mockDb({
+      u1: [{ result: 'won' }, { result: 'won' }],
+    });
+    /** @type {import('firebase-admin/auth').Auth} */
+    const auth = /** @type {import('firebase-admin/auth').Auth} */ ({
+      async getUsers(identifiers) {
+        const byUid = {
+          u1: {
+            uid: 'u1',
+            email: 'mystery_user@gmail.com',
+            displayName: '',
+            emailVerified: true,
+          },
+        };
+        const users = identifiers
+          .map((/** @type {{ uid: string }} */ id) => byUid[id.uid])
+          .filter(Boolean);
+        return { users, notFound: [] };
+      },
+    });
+    const standings = await computeStandingsForEntryDocs(
+      /** @type {import('firebase-admin/firestore').Firestore} */ (db),
+      { windowStart: ws, windowEnd: we, leagueGamesN },
+      [entryDoc('u1', 0, null)],
+      { auth },
+    );
+    assert.equal(standings.length, 1);
+    assert.equal(standings[0].displayName, 'mystery_user');
+  });
+
   it('is deterministic for identical frozen inputs (live vs E2)', async () => {
     const ws = ts(100);
     const we = ts(9_000_000);

--- a/server/lib/auth-display-names.js
+++ b/server/lib/auth-display-names.js
@@ -3,13 +3,53 @@
  */
 
 /**
+ * Part before `@`; mirrors `src/app/auth/user-display-name.util.ts` (`emailLocalPart`).
+ *
+ * @param {string | null | undefined} email
+ * @returns {string | null}
+ */
+export function emailLocalPartFromEmail(email) {
+  if (email == null || typeof email !== 'string') {
+    return null;
+  }
+  const t = email.trim();
+  if (!t) {
+    return null;
+  }
+  const at = t.indexOf('@');
+  if (at <= 0) {
+    return t;
+  }
+  const local = t.slice(0, at).trim();
+  return local || null;
+}
+
+/**
+ * Contest standings / `results/final` row label: join snapshot when set, else Auth email local part.
+ *
+ * @param {string | null} displayNameSnapshot
+ * @param {string | null | undefined} authEmail
+ * @returns {string | null}
+ */
+export function contestStandingDisplayLabel(displayNameSnapshot, authEmail) {
+  const snap =
+    displayNameSnapshot === null || typeof displayNameSnapshot !== 'string'
+      ? ''
+      : displayNameSnapshot.trim();
+  if (snap) {
+    return snap;
+  }
+  return emailLocalPartFromEmail(authEmail);
+}
+
+/**
  * @param {string[]} uids
  * @param {import('firebase-admin/auth').Auth} auth
- * @returns {Promise<Map<string, { displayName: string | null, emailVerified: boolean }>>}
+ * @returns {Promise<Map<string, { displayName: string | null, emailVerified: boolean, email: string | null }>>}
  */
 export async function fetchAuthFieldsForUids(uids, auth) {
   if (uids.length === 0) return new Map();
-  /** @type {Map<string, { displayName: string | null, emailVerified: boolean }>} */
+  /** @type {Map<string, { displayName: string | null, emailVerified: boolean, email: string | null }>} */
   const out = new Map();
   const chunkSize = 100;
   for (let i = 0; i < uids.length; i += chunkSize) {
@@ -18,21 +58,23 @@ export async function fetchAuthFieldsForUids(uids, auth) {
       const res = await auth.getUsers(chunk.map((uid) => ({ uid })));
       for (const u of res.users) {
         const dn = u.displayName;
+        const em = u.email;
         out.set(u.uid, {
           displayName:
             typeof dn === 'string' && dn.trim() ? dn.trim() : null,
           emailVerified: Boolean(u.emailVerified),
+          email: typeof em === 'string' && em.trim() ? em.trim() : null,
         });
       }
       for (const uid of chunk) {
         if (!out.has(uid)) {
-          out.set(uid, { displayName: null, emailVerified: false });
+          out.set(uid, { displayName: null, emailVerified: false, email: null });
         }
       }
     } catch {
       for (const uid of chunk) {
         if (!out.has(uid)) {
-          out.set(uid, { displayName: null, emailVerified: false });
+          out.set(uid, { displayName: null, emailVerified: false, email: null });
         }
       }
     }

--- a/server/lib/auth-display-names.test.js
+++ b/server/lib/auth-display-names.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  contestStandingDisplayLabel,
+  emailLocalPartFromEmail,
+} from './auth-display-names.js';
+
+describe('emailLocalPartFromEmail', () => {
+  it('returns substring before @', () => {
+    assert.equal(emailLocalPartFromEmail('  nick@example.com '), 'nick');
+  });
+
+  it('returns null for empty or missing', () => {
+    assert.equal(emailLocalPartFromEmail(null), null);
+    assert.equal(emailLocalPartFromEmail(''), null);
+    assert.equal(emailLocalPartFromEmail('   '), null);
+  });
+
+  it('returns full trim when no @', () => {
+    assert.equal(emailLocalPartFromEmail('nolabel'), 'nolabel');
+  });
+});
+
+describe('contestStandingDisplayLabel', () => {
+  it('prefers non-empty snapshot', () => {
+    assert.equal(
+      contestStandingDisplayLabel('Aaron', 'other@x.com'),
+      'Aaron',
+    );
+  });
+
+  it('uses email local part when snapshot null or blank', () => {
+    assert.equal(
+      contestStandingDisplayLabel(null, 'mystery_user@gmail.com'),
+      'mystery_user',
+    );
+    assert.equal(contestStandingDisplayLabel('  ', 'a@b.co'), 'a');
+  });
+
+  it('returns null when no snapshot and no email', () => {
+    assert.equal(contestStandingDisplayLabel(null, null), null);
+    assert.equal(contestStandingDisplayLabel(null, ''), null);
+  });
+});


### PR DESCRIPTION
…me Logic

- Updated the leaderboard API to utilize Firebase Auth for fetching user display names, improving the accuracy of participant identification.
- Revised the documentation for the `standings` field to clarify how display names are derived, including fallback mechanisms to use the local part of the user's email when necessary.
- Enhanced the `computeStandingsForEntryDocs` function to incorporate authentication details, ensuring that display names are populated correctly based on user data.
- Added tests to verify the new display name logic, ensuring consistent behavior across different scenarios.