### PR TITLE
Update environment configuration for contest payments

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@
 #   _FIREBASE_API_KEY, _FIREBASE_AUTH_DOMAIN, _FIREBASE_PROJECT_ID,
 #   _FIREBASE_STORAGE_BUCKET, _FIREBASE_MESSAGING_SENDER_ID, _FIREBASE_APP_ID
 # Optional: _FIREBASE_MEASUREMENT_ID, _API_BASE_URL, _DEPLOYMENT (default production; use `staging` + staging Firebase subs for a staging service)
-# Optional: _CONTESTS_PAYMENTS_ENABLED (default `false`) — Express + staging Angular paid entry; production SPA ignores this (always off). Staging QA: set `true`.
+# Optional: _CONTESTS_PAYMENTS_ENABLED (default `true`) — Express + Angular paid entry toggle for the built/deployed target.
 # Optional: _AUTH_SESSION_MAX_DAYS — Angular `authSessionMaxMs` (see generate-env-prod.mjs). `0`/`off` = no forced logout. Prod default 3d if unset; staging default 0 if unset.
 # Optional Stripe (Phase 1): _STRIPE_PUBLISHABLE_KEY — test (`pk_test_`) for staging trigger, live (`pk_live_`) for prod only (see docs/stripe.md)
 #
@@ -102,8 +102,8 @@ substitutions:
   _FIREBASE_MEASUREMENT_ID: ''
   # Story AD-4 — optional; omit or empty = admin UI enabled (same as LEADERBOARDS_UI_ENABLED pattern)
   _ADMIN_DASHBOARD_UI_ENABLED: ''
-  # Story P5 — server + staging build: live/test paid entry off unless trigger sets `true`
-  _CONTESTS_PAYMENTS_ENABLED: 'false'
+  # Story P5 — default on for production builds/deploys; override to `false` per trigger/environment if needed.
+  _CONTESTS_PAYMENTS_ENABLED: 'true'
   _AUTH_SESSION_MAX_DAYS: ''
 
 options:

--- a/scripts/generate-env-prod.mjs
+++ b/scripts/generate-env-prod.mjs
@@ -73,11 +73,10 @@ const adminDashboardUiEnabled = process.env.ADMIN_DASHBOARD_UI_ENABLED !== 'fals
 
 /**
  * Story P5-D2 — paid entry UX in the SPA (Stripe Checkout redirect).
- * Production: always false (no live paid checkout in the prod bundle).
- * Staging: true only when build receives `CONTESTS_PAYMENTS_ENABLED=true` (match server QA).
+ * Enabled only when the build explicitly sets `CONTESTS_PAYMENTS_ENABLED=true`
+ * (applies to staging and production builds).
  */
-const contestsPaymentsEnabled =
-  isStaging && process.env.CONTESTS_PAYMENTS_ENABLED === 'true';
+const contestsPaymentsEnabled = process.env.CONTESTS_PAYMENTS_ENABLED === 'true';
 
 /** Max session from last auth (`authTime`). 0 = disabled. Prod defaults to 3d if unset; staging defaults to 0. */
 const authSessionMaxDaysRaw = (process.env.AUTH_SESSION_MAX_DAYS ?? '').trim();


### PR DESCRIPTION
- Changed the default value of `_CONTESTS_PAYMENTS_ENABLED` to `true` in `cloudbuild.yaml`, allowing paid entry for production builds.
- Updated the logic in `generate-env-prod.mjs` to enable paid entry only when explicitly set, ensuring consistent behavior across staging and production environments.