### PR TITLE
Update maximum size limits for component styles in angular.json

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -50,8 +50,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "15kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ],
               "outputHashing": "all",
@@ -69,8 +69,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "15kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
- Increased the maximum warning size from 6kb to 12kb and the maximum error size from 15kb to 20kb for anyComponentStyle, allowing for larger component styles without triggering warnings or errors.
- This change aims to improve flexibility in style management while maintaining performance standards.