### PR TITLE
Update environment configuration for simulated contests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,9 +107,9 @@
 # Phase 5 — when true, STRIPE_SECRET_KEY is required or the server exits on startup (server/stripe-server.js).
 # Angular `contestsPaymentsEnabled` is set from the same flag at production/staging build (`generate-env-prod.mjs`).
 # CONTESTS_PAYMENTS_ENABLED=true
-# Weekly contests — Angular `simulatedContestsUiEnabled` (dry-run / “simulated” copy vs live-oriented copy).
-# Set `false` to hide simulated disclaimers while keeping the contests UI (`WEEKLY_CONTESTS_UI_ENABLED` still controls the drawer). `generate-env-prod.mjs`
-# SIMULATED_CONTESTS_UI_ENABLED=false
+# Weekly contests — Angular `simulatedContestsUiEnabled` (dashed strip, “Simulated” copy, dry-run payout headings).
+# `generate-env-prod.mjs`: **production** defaults to off; set `SIMULATED_CONTESTS_UI_ENABLED=true` to opt in. **Staging** defaults to on; set `false` to turn off.
+# SIMULATED_CONTESTS_UI_ENABLED=true
 # Optional — max signed-in session length in days for production/staging Angular builds (`generate-env-prod.mjs` → `authSessionMaxMs`).
 # `0`, `off`, `false`, `none` = no forced logout. Positive number = days. Unset in production Docker build defaults to 3; staging defaults to 0.
 # AUTH_SESSION_MAX_DAYS=3

--- a/scripts/generate-env-prod.mjs
+++ b/scripts/generate-env-prod.mjs
@@ -61,9 +61,14 @@ const leaderboardsUiEnabled = process.env.LEADERBOARDS_UI_ENABLED !== 'false';
 /** Story C2 — omit weekly contests drawer when WEEKLY_CONTESTS_UI_ENABLED=false */
 const weeklyContestsUiEnabled = process.env.WEEKLY_CONTESTS_UI_ENABLED !== 'false';
 
-/** Simulated / dry-run messaging — omit when SIMULATED_CONTESTS_UI_ENABLED=false */
-const simulatedContestsUiEnabled =
-  process.env.SIMULATED_CONTESTS_UI_ENABLED !== 'false';
+/**
+ * Simulated / dry-run contest strip + card copy.
+ * - **Production:** off unless `SIMULATED_CONTESTS_UI_ENABLED=true` (explicit opt-in).
+ * - **Staging:** on unless `SIMULATED_CONTESTS_UI_ENABLED=false`.
+ */
+const simulatedContestsUiEnabled = isStaging
+  ? process.env.SIMULATED_CONTESTS_UI_ENABLED !== 'false'
+  : process.env.SIMULATED_CONTESTS_UI_ENABLED === 'true';
 
 /**
  * Phase 0 — omit “Weekly contest” tab inside the leaderboard panel when LEADERBOARD_CONTEST_TAB_ENABLED=false.

--- a/src/environment.prod.ts
+++ b/src/environment.prod.ts
@@ -17,6 +17,8 @@ export const environment = {
   leaderboardUseFirestoreSnapshot: false,
   leaderboardsUiEnabled: true,
   weeklyContestsUiEnabled: true,
+  /** Overwritten by `generate-env-prod.mjs` — production defaults to false (live-oriented contest UX). */
+  simulatedContestsUiEnabled: false,
   adminDashboardUiEnabled: true,
   /** Production: always false in CI output (`generate-env-prod.mjs`). Paid entry UX stays off until policy changes. */
   contestsPaymentsEnabled: false,


### PR DESCRIPTION
- Revised the `.env.example` file to clarify the behavior of the `SIMULATED_CONTESTS_UI_ENABLED` flag, specifying defaults for production and staging environments.
- Enhanced the `generate-env-prod.mjs` script to accurately reflect the conditions under which simulated contests are displayed based on the environment.
- Updated `environment.prod.ts` to ensure the `simulatedContestsUiEnabled` flag defaults to false in production, aligning with the new configuration guidelines.